### PR TITLE
Disable caching on loadurl AJAX request

### DIFF
--- a/jquery.jeditable.js
+++ b/jquery.jeditable.js
@@ -220,6 +220,7 @@
                        url  : settings.loadurl,
                        data : loaddata,
                        async : false,
+                       cache : false,
                        success: function(result) {
                           window.clearTimeout(t);
                           input_content = result;


### PR DESCRIPTION
The cache option for the jQuery $.ajax call is set to "true" by default, telling the browser it can cache the AJAX requests.  IE8 honors this (FF does not) which results in all responses from the loadurl being cached and the field being edited always showing the first response it received.  This caching is kept even when the page is reloaded adding to the confusion.  Setting cache to "false" tells the browser not to cache the $.ajax response and makes Jeditable work as expected in IE8.
