### PR TITLE
`.html()` → `.text()`

### DIFF
--- a/jquery.jeditable.js
+++ b/jquery.jeditable.js
@@ -171,7 +171,7 @@
                 }
                                 
                 self.editing    = true;
-                self.revert     = $(self).html();
+                self.revert     = $(self).text();
                 $(self).html('');
 
                 /* Create the form object. */
@@ -309,7 +309,7 @@
                           /* Check if given target is function */
                           if ($.isFunction(settings.target)) {
                               var str = settings.target.apply(self, [input.val(), settings]);
-                              $(self).html(str);
+                              $(self).text(str);
                               self.editing = false;
                               callback.apply(self, [self.innerHTML, settings]);
                               /* TODO: this is not dry */                              
@@ -378,7 +378,7 @@
                 if (this.editing) {
                     /* Before reset hook, if it returns false abort reseting. */
                     if (false !== onreset.apply(form, [settings, self])) { 
-                        $(self).html(self.revert);
+                        $(self).text(self.revert);
                         self.editing   = false;
                         if (!$.trim($(self).html())) {
                             $(self).html(settings.placeholder);


### PR DESCRIPTION
It's quite likely that I'm using the plugin incorrectly, but I've encountered a couple of issues (two sides of the same coin, actually):
- Editing `X&Y` populates the input field with `X&amp;Y`
- Replacing the text with `<b>Z</b>` results in a `b` tag being inserted into the DOM

Is there a way to tell the plugin to pass around plaintext rather than HTML? If not, perhaps my change is useful. Whatever the solution, it should not involve presenting the user with HTML character entities. ;)
