### PR TITLE
Adding support for passing a 'label' to the editable field

### DIFF
--- a/jquery.jeditable.js
+++ b/jquery.jeditable.js
@@ -196,6 +196,12 @@
                     }
                 }
 
+                /* Add (optional) form input label for user instructions, etc */
+                if(settings.label)
+                {
+                     form.append("<label>"+settings.label+"</label>");
+                }
+
                 /* Add main input element to form and store it in input. */
                 var input = element.apply(form, [settings, self]);
 


### PR DESCRIPTION
Adding support for passing a 'label' to provide instructions, field description, etc to the user, since the placeholder disappears. (once the user clicks on the container, without any instructions/description, they may not know what the box is for)
