### PR TITLE
adjust width right after appending form to keep outer layout

### DIFF
--- a/jquery.jeditable.js
+++ b/jquery.jeditable.js
@@ -244,6 +244,12 @@
                 /* Add created form to self. */
                 $(self).append(form);
          
+                /* adjust width */
+                if (settings.width != 'none') {
+                    var adj_width = settings.width - (input.outerWidth(true) - settings.width);
+                    input.width(adj_width);
+                }
+
                 /* Attach 3rd party plugin if requested. */
                 plugin.apply(form, [settings, self]);
 


### PR DESCRIPTION
width: 'auto' setting define input/textarea element width by using jQuery.width(original). which is trying to give the same pixels to inner input/textarea element but it causes layout issues because most browsers add border into input/textfield and fields run off from original block element.
