### PR TITLE
Added idattr setting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 VERSION = 1.7.1
 SHELL = /bin/sh
 DOWNLOAD = /var/www/www.appelsiini.net/htdocs/download
-JSPACKER = /home/tuupola/bin/jspacker
-JSMIN    = /home/tuupola/bin/jsmin
+JSPACKER = ~/bin/jspacker
+JSMIN    = ~/bin/jsmin
 
 #all: jeditable packed minified latest wysiwyg
 all: jeditable minified latest wysiwyg
@@ -11,14 +11,14 @@ jeditable: jquery.jeditable.js
 	cp jquery.jeditable.js $(DOWNLOAD)/jquery.jeditable-$(VERSION).js
 
 packed: jquery.jeditable.js
-	$(JSPACKER) < jquery.jeditable.js > jquery.jeditable.pack.js 
+	$(JSPACKER) < jquery.jeditable.js > jquery.jeditable.pack.js
 	cp jquery.jeditable.pack.js $(DOWNLOAD)/jquery.jeditable-$(VERSION).pack.js
 
 minified: jquery.jeditable.js
-	$(JSMIN) < jquery.jeditable.js > jquery.jeditable.mini.js 
+	$(JSMIN) < jquery.jeditable.js > jquery.jeditable.mini.js
 	cp jquery.jeditable.mini.js $(DOWNLOAD)/jquery.jeditable-$(VERSION).mini.js
 
-latest: jquery.jeditable.js jquery.jeditable.pack.js 
+latest: jquery.jeditable.js jquery.jeditable.pack.js
 	cp jquery.jeditable.js $(DOWNLOAD)/jquery.jeditable.js
 	cp jquery.jeditable.ajaxupload.js $(DOWNLOAD)/jquery.jeditable.ajaxupload.js
 	cp jquery.jeditable.autogrow.js $(DOWNLOAD)/jquery.jeditable.autogrow.js

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION = 1.7.1
+VERSION = 1.7.3
 SHELL = /bin/sh
 DOWNLOAD = /var/www/www.appelsiini.net/htdocs/download
 JSPACKER = ~/bin/jspacker

--- a/README.textile
+++ b/README.textile
@@ -1,5 +1,8 @@
 h3. Changelog
 
+h4. 1.7.3
+* Added option to use a different attribute for the id value
+
 h4. 1.7.2
 
 * Submit on change if input type select and no submit button defined ("gregpyp":http://github.com/gregpyp)
@@ -18,7 +21,7 @@ h4. 1.7.0
 * Full control over jQuery AJAX options for those who want to tinker.
 * Fix problem with IE and placeholder with HTML tags.
 * Add $.editable('disable'), $.editable('enable') and $.editable('destroy')
-* Add onedit, onsubmit, onreset and onerror hooks. 
+* Add onedit, onsubmit, onreset and onerror hooks.
 * Allow passing select options as JavaScript object.
 * Fix IE throwing error with textareas when width or height was set to 'none'.
 
@@ -35,5 +38,5 @@ h4. 1.6.0
 
 * Onblur parameter can now be a function.
 * Support for any arbitary event for triggering Jeditable
-* Submitting of form will be canceled if submit() method of custom input returns false. 
-* Custom inputs now have access to reset() method. 
+* Submitting of form will be canceled if submit() method of custom input returns false.
+* Custom inputs now have access to reset() method.

--- a/jquery.jeditable.js
+++ b/jquery.jeditable.js
@@ -17,19 +17,20 @@
 /**
   * Version 1.7.2-dev
   *
-  * ** means there is basic unit tests for this parameter. 
+  * ** means there is basic unit tests for this parameter.
   *
   * @name  Jeditable
   * @type  jQuery
   * @param String  target             (POST) URL or function to send edited content to **
-  * @param Hash    options            additional options 
+  * @param Hash    options            additional options
   * @param String  options[method]    method to use to send edited content (POST or PUT) **
   * @param Function options[callback] Function to run after submitting edited content **
   * @param String  options[name]      POST parameter name of edited content
   * @param String  options[id]        POST parameter name of edited div id
+  * @param String  options[idattr]    Element attribute name to use as the submitted id
   * @param Hash    options[submitdata] Extra parameters to send when submitting edited content.
   * @param String  options[type]      text, textarea or select (or any 3rd party input type) **
-  * @param Integer options[rows]      number of rows if using textarea ** 
+  * @param Integer options[rows]      number of rows if using textarea **
   * @param Integer options[cols]      number of columns if using textarea **
   * @param Mixed   options[height]    'auto', 'none' or height in pixels **
   * @param Mixed   options[width]     'auto', 'none' or width in pixels **
@@ -48,19 +49,19 @@
   * @param String  options[select]    true or false, when true text is highlighted ??
   * @param String  options[placeholder] Placeholder text or html to insert when element is empty. **
   * @param String  options[onblur]    'cancel', 'submit', 'ignore' or function ??
-  *             
+  *
   * @param Function options[onsubmit] function(settings, original) { ... } called before submit
   * @param Function options[onreset]  function(settings, original) { ... } called before reset
   * @param Function options[onerror]  function(settings, original, xhr) { ... } called on error
-  *             
+  *
   * @param Hash    options[ajaxoptions]  jQuery Ajax options. See docs.jquery.com.
-  *             
+  *
   */
 
 (function($) {
 
     $.fn.editable = function(target, options) {
-            
+
         if ('disable' == target) {
             $(this).data('disabled.editable', true);
             return;
@@ -76,39 +77,39 @@
                 .removeData('event.editable');
             return;
         }
-        
+
         var settings = $.extend({}, $.fn.editable.defaults, {target:target}, options);
-        
+
         /* setup some functions */
         var plugin   = $.editable.types[settings.type].plugin || function() { };
         var submit   = $.editable.types[settings.type].submit || function() { };
-        var buttons  = $.editable.types[settings.type].buttons 
+        var buttons  = $.editable.types[settings.type].buttons
                     || $.editable.types['defaults'].buttons;
-        var content  = $.editable.types[settings.type].content 
+        var content  = $.editable.types[settings.type].content
                     || $.editable.types['defaults'].content;
-        var element  = $.editable.types[settings.type].element 
+        var element  = $.editable.types[settings.type].element
                     || $.editable.types['defaults'].element;
-        var reset    = $.editable.types[settings.type].reset 
+        var reset    = $.editable.types[settings.type].reset
                     || $.editable.types['defaults'].reset;
         var callback = settings.callback || function() { };
-        var onedit   = settings.onedit   || function() { }; 
+        var onedit   = settings.onedit   || function() { };
         var onsubmit = settings.onsubmit || function() { };
         var onreset  = settings.onreset  || function() { };
         var onerror  = settings.onerror  || reset;
-          
+
         /* Show tooltip. */
         if (settings.tooltip) {
             $(this).attr('title', settings.tooltip);
         }
-        
+
         settings.autowidth  = 'auto' == settings.width;
         settings.autoheight = 'auto' == settings.height;
-        
+
         return this.each(function() {
-                        
+
             /* Save this to self because this changes when scope changes. */
-            var self = this;  
-                   
+            var self = this;
+
             /* Inlined block elements lose their width and height after first edit. */
             /* Save them for later use as workaround. */
             var savedwidth  = $(self).width();
@@ -116,38 +117,38 @@
 
             /* Save so it can be later used by $.editable('destroy') */
             $(this).data('event.editable', settings.event);
-            
+
             /* If element is empty add something clickable (if requested) */
             if (!$.trim($(this).html())) {
                 $(this).html(settings.placeholder);
             }
-            
+
             $(this).bind(settings.event, function(e) {
-                
+
                 /* Abort if element is disabled. */
                 if (true === $(this).data('disabled.editable')) {
                     return;
                 }
-                
+
                 /* Prevent throwing an exeption if edit field is clicked again. */
                 if (self.editing) {
                     return;
                 }
-                
+
                 /* Abort if onedit hook returns false. */
                 if (false === onedit.apply(this, [settings, self])) {
                    return;
                 }
-                
+
                 /* Prevent default action and bubbling. */
                 e.preventDefault();
                 e.stopPropagation();
-                
+
                 /* Remove tooltip. */
                 if (settings.tooltip) {
                     $(self).removeAttr('title');
                 }
-                
+
                 /* Figure out how wide and tall we are, saved width and height. */
                 /* Workaround for http://dev.jquery.com/ticket/2190 */
                 if (0 == $(self).width()) {
@@ -155,28 +156,28 @@
                     settings.height = savedheight;
                 } else {
                     if (settings.width != 'none') {
-                        settings.width = 
+                        settings.width =
                             settings.autowidth ? $(self).width()  : settings.width;
                     }
                     if (settings.height != 'none') {
-                        settings.height = 
+                        settings.height =
                             settings.autoheight ? $(self).height() : settings.height;
                     }
                 }
-                
+
                 /* Remove placeholder text, replace is here because of IE. */
-                if ($(this).html().toLowerCase().replace(/(;|"|\/)/g, '') == 
+                if ($(this).html().toLowerCase().replace(/(;|"|\/)/g, '') ==
                     settings.placeholder.toLowerCase().replace(/(;|"|\/)/g, '')) {
                         $(this).html('');
                 }
-                                
+
                 self.editing    = true;
                 self.revert     = $(self).html();
                 $(self).html('');
 
                 /* Create the form object. */
                 var form = $('<form />');
-                
+
                 /* Apply css or style or both. */
                 if (settings.cssclass) {
                     if ('inherit' == settings.cssclass) {
@@ -190,7 +191,7 @@
                     if ('inherit' == settings.style) {
                         form.attr('style', $(self).attr('style'));
                         /* IE needs the second line or display wont be inherited. */
-                        form.css('display', $(self).css('display'));                
+                        form.css('display', $(self).css('display'));
                     } else {
                         form.attr('style', settings.style);
                     }
@@ -201,7 +202,7 @@
 
                 /* Set input content via POST, GET, given data or existing value. */
                 var input_content;
-                
+
                 if (settings.loadurl) {
                     var t = setTimeout(function() {
                         input.disabled = true;
@@ -209,7 +210,13 @@
                     }, 100);
 
                     var loaddata = {};
-                    loaddata[settings.id] = self.id;
+                    if (settings.idattr) {
+                        alert(settings.idattr);
+                        loaddata[settings.id] = $(self).attr(settings.idattr);
+                    } else {
+                        alert('all normal');
+                        loaddata[settings.id] = self.id;
+                    }
                     if ($.isFunction(settings.loaddata)) {
                         $.extend(loaddata, settings.loaddata.apply(self, [self.revert, settings]));
                     } else {
@@ -232,18 +239,18 @@
                         input_content = settings.data.apply(self, [self.revert, settings]);
                     }
                 } else {
-                    input_content = self.revert; 
+                    input_content = self.revert;
                 }
                 content.apply(form, [input_content, settings, self]);
 
                 input.attr('name', settings.name);
-        
+
                 /* Add buttons to the form. */
                 buttons.apply(form, [settings, self]);
-         
+
                 /* Add created form to self. */
                 $(self).append(form);
-         
+
                 /* Attach 3rd party plugin if requested. */
                 plugin.apply(form, [settings, self]);
 
@@ -254,7 +261,7 @@
                 if (settings.select) {
                     input.select();
                 }
-        
+
                 /* discard changes if pressing esc */
                 input.keydown(function(e) {
                     if (e.keyCode == 27) {
@@ -292,19 +299,19 @@
 
                 form.submit(function(e) {
 
-                    if (t) { 
+                    if (t) {
                         clearTimeout(t);
                     }
 
                     /* Do no submit. */
-                    e.preventDefault(); 
-            
+                    e.preventDefault();
+
                     /* Call before submit hook. */
-                    /* If it returns false abort submitting. */                    
-                    if (false !== onsubmit.apply(form, [settings, self])) { 
+                    /* If it returns false abort submitting. */
+                    if (false !== onsubmit.apply(form, [settings, self])) {
                         /* Custom inputs call before submit hook. */
                         /* If it returns false abort submitting. */
-                        if (false !== submit.apply(form, [settings, self])) { 
+                        if (false !== submit.apply(form, [settings, self])) {
 
                           /* Check if given target is function */
                           if ($.isFunction(settings.target)) {
@@ -312,7 +319,7 @@
                               $(self).html(str);
                               self.editing = false;
                               callback.apply(self, [self.innerHTML, settings]);
-                              /* TODO: this is not dry */                              
+                              /* TODO: this is not dry */
                               if (!$.trim($(self).html())) {
                                   $(self).html(settings.placeholder);
                               }
@@ -320,7 +327,12 @@
                               /* Add edited content and id of edited element to POST. */
                               var submitdata = {};
                               submitdata[settings.name] = input.val();
-                              submitdata[settings.id] = self.id;
+                              if (settings.idattr) {
+                                  alert(loaddata);
+                                  loaddata[settings.id] = $(self).attr(settings.idattr);
+                              } else {
+                                  submitdata[settings.id] = self.id;
+                              }
                               /* Add extra data to be POST:ed. */
                               if ($.isFunction(settings.submitdata)) {
                                   $.extend(submitdata, settings.submitdata.apply(self, [self.revert, settings]));
@@ -335,7 +347,7 @@
 
                               /* Show the saving indicator. */
                               $(self).html(settings.indicator);
-                              
+
                               /* Defaults for ajaxoptions. */
                               var ajaxoptions = {
                                   type    : 'POST',
@@ -356,28 +368,28 @@
                                       onerror.apply(form, [settings, self, xhr]);
                                   }
                               };
-                              
+
                               /* Override with what is given in settings.ajaxoptions. */
-                              $.extend(ajaxoptions, settings.ajaxoptions);   
-                              $.ajax(ajaxoptions);          
-                              
+                              $.extend(ajaxoptions, settings.ajaxoptions);
+                              $.ajax(ajaxoptions);
+
                             }
                         }
                     }
-                    
+
                     /* Show tooltip again. */
                     $(self).attr('title', settings.tooltip);
-                    
+
                     return false;
                 });
             });
-            
+
             /* Privileged methods */
             this.reset = function(form) {
                 /* Prevent calling reset twice when blurring. */
                 if (this.editing) {
                     /* Before reset hook, if it returns false abort reseting. */
-                    if (false !== onreset.apply(form, [settings, self])) { 
+                    if (false !== onreset.apply(form, [settings, self])) {
                         $(self).html(self.revert);
                         self.editing   = false;
                         if (!$.trim($(self).html())) {
@@ -385,11 +397,11 @@
                         }
                         /* Show tooltip again. */
                         if (settings.tooltip) {
-                            $(self).attr('title', settings.tooltip);                
+                            $(self).attr('title', settings.tooltip);
                         }
-                    }                    
+                    }
                 }
-            };            
+            };
         });
 
     };
@@ -399,7 +411,7 @@
         types: {
             defaults: {
                 element : function(settings, original) {
-                    var input = $('<input type="hidden"></input>');                
+                    var input = $('<input type="hidden"></input>');
                     $(this).append(input);
                     return(input);
                 },
@@ -422,7 +434,7 @@
                         /* Otherwise use button with given string as text. */
                         } else {
                             var submit = $('<button type="submit" />');
-                            submit.html(settings.submit);                            
+                            submit.html(settings.submit);
                         }
                         $(this).append(submit);
                     }
@@ -439,9 +451,9 @@
 
                         $(cancel).click(function(event) {
                             if ($.isFunction($.editable.types[settings.type].reset)) {
-                                var reset = $.editable.types[settings.type].reset;                                                                
+                                var reset = $.editable.types[settings.type].reset;
                             } else {
-                                var reset = $.editable.types['defaults'].reset;                                
+                                var reset = $.editable.types['defaults'].reset;
                             }
                             reset.apply(form, [settings, original]);
                             return false;
@@ -486,7 +498,7 @@
                 },
                 content : function(data, settings, original) {
                     /* If it is string assume it is json. */
-                    if (String == data.constructor) {      
+                    if (String == data.constructor) {
                         eval ('var json = ' + data);
                     } else {
                     /* Otherwise assume it is a hash already. */
@@ -498,13 +510,13 @@
                         }
                         if ('selected' == key) {
                             continue;
-                        } 
+                        }
                         var option = $('<option />').val(key).append(json[key]);
-                        $('select', this).append(option);    
-                    }                    
-                    /* Loop option again to set selected. IE needed this... */ 
+                        $('select', this).append(option);
+                    }
+                    /* Loop option again to set selected. IE needed this... */
                     $('select', this).children().each(function() {
-                        if ($(this).val() == json['selected'] || 
+                        if ($(this).val() == json['selected'] ||
                             $(this).text() == $.trim(original.revert)) {
                                 $(this).attr('selected', 'selected');
                         }
@@ -530,6 +542,7 @@
     $.fn.editable.defaults = {
         name       : 'value',
         id         : 'id',
+        idattr     : 'id',
         type       : 'text',
         width      : 'auto',
         height     : 'auto',

--- a/jquery.jeditable.js
+++ b/jquery.jeditable.js
@@ -15,7 +15,7 @@
  */
 
 /**
-  * Version 1.7.2-dev
+  * Version 1.7.3
   *
   * ** means there is basic unit tests for this parameter.
   *
@@ -211,7 +211,6 @@
 
                     var loaddata = {};
                     if (settings.idattr) {
-                        alert(settings.idattr);
                         loaddata[settings.id] = $(self).attr(settings.idattr);
                     } else {
                         alert('all normal');
@@ -328,8 +327,7 @@
                               var submitdata = {};
                               submitdata[settings.name] = input.val();
                               if (settings.idattr) {
-                                  alert(loaddata);
-                                  loaddata[settings.id] = $(self).attr(settings.idattr);
+                                  submitdata[settings.id] = $(self).attr(settings.idattr);
                               } else {
                                   submitdata[settings.id] = self.id;
                               }

--- a/tests/id.php
+++ b/tests/id.php
@@ -1,0 +1,2 @@
+<?php
+print $_POST["id"];

--- a/tests/index.html
+++ b/tests/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" 
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
                     "http://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
@@ -9,12 +9,12 @@
 <script type="text/javascript" src="../jquery.jeditable.js"></script>
 <script>
 $(document).ready(function() {
-    
+
     //window.loadFirebugConsole();
     /* We need synchronous AJAX for testing. */
     $.ajaxSetup({
         async : false
-    }); 
+    });
     $("#post").editable("method.php", {
         loadurl   : "load.php",
         type      : "textarea",
@@ -38,7 +38,7 @@ $(document).ready(function() {
         event     : "dblclick",
         submit    : "<i>Click to submit</i>",
         onblur    : "ignore"
-    });  
+    });
     $("#placeholder").editable("echo.php", {
         placeholder : "PLACEHOLDER",
         width     : 200,
@@ -65,8 +65,13 @@ $(document).ready(function() {
     }, {
         submit  : "OK"
     });
-    
-    module("CORE");    
+	$("#differentId").editable("id.php", {
+        submit  : "OK",
+		idattr: 'data-model-id',
+    });
+
+
+    module("CORE");
 
     test("Event triggers", function() {
         $("#post").trigger("click");
@@ -98,8 +103,8 @@ $(document).ready(function() {
         $("#placeholder form").submit();
 
         $("#select").trigger("click");
-        equals($("#select :input:first").attr("type"), "select-one", "Should be select-one");      
-        equals($("#select :selected").html(), "Select B", "Should be Select B");        
+        equals($("#select :input:first").attr("type"), "select-one", "Should be select-one");
+        equals($("#select :selected").html(), "Select B", "Should be Select B");
         $("#select form").submit();
     });
 
@@ -109,7 +114,7 @@ $(document).ready(function() {
         $("#function form").submit();
         equals($("#function").html(), "Pacman", 'Target function returns Pacman');
     });
-    
+
     test("Onblur events", function() {
         /* How to work around timeout problem? */
     });
@@ -122,11 +127,12 @@ $(document).ready(function() {
     });
 
     test("Tooltip", function() {
+	  console.log($('#post').attr('title'));
       equals($("#post").attr("title"), "Tooltip", "Should be tooltip.");
       equals($("#put").attr("title"), "Tooltip", "Should be tooltip.");
       equals($("#select").attr("title"), "Tooltip", "Should be tooltip.");
     });
-    
+
     test("Select", function() {
         /* How to access selection? */
     });
@@ -135,62 +141,68 @@ $(document).ready(function() {
       $("#post").trigger("click");
       equals($("#post form").css("display"), "inline", "Should inherit inline");
       $("#put").trigger("click");
-      equals($("#put form").css("margin-top"), "27px", "Should be 27px");      
+      equals($("#put form").css("margin-top"), "27px", "Should be 27px");
     });
-    
+
     test("CSS class", function() {
       $("#post").trigger("click");
       ok($("#post form").hasClass("foo"), "Should inherit class foo.");
       $("#put").trigger("click");
       ok($("#put form").hasClass("bar"), "Should have class bar.");
     });
-    
-    test("Buttons", function() {      
+
+    test("Buttons", function() {
       $("#post").trigger("click");
-      ok($("#post button[type=submit]").size() == 1, "Should have submit button.");
+      ok($("#post button:first").attr('type') == 'submit', "Should have submit button.");
       ok($("#post button").size() == 2, "Should have cancel button too.");
       $("#put").trigger("click");
       $("#put form i").html();
       $("#put form i").trigger("click");
     });
-    
+
     test("Placeholder", function() {
         equals($("#placeholder").html(), "PLACEHOLDER", "Should be PLACEHOLDER");
         $("#placeholder").trigger("edit");
         equals($("#placeholder input").html(), "", "Should be empty");
         $("#placeholder form").submit();
         equals($("#placeholder").html(), "PLACEHOLDER", "Should be PLACEHOLDER");
-        
+
         $("#placeholder").trigger("edit");
         $("#placeholder input").val("NEW VALUE");
         $("#placeholder form").submit();
         equals($("#placeholder").html(), "NEW VALUE", "Should be PLACEHOLDER");
     });
-    
+
     test("Callback", function() {
         $("#callback").trigger("click");
         $("#callback form").trigger("submit");
         equals($("#callback").html(), "Dragons begone.", "Dragons should be gone");
     });
-    
+
+    test("Different Id Attribute", function() {
+        $("#differentId").click();
+        $("#differentId form").submit();
+        equals($("#differentId").html(), "3", "Should be 3");
+    });
+
     module("AJAH");
     test("Submit methods", function() {
         $("#post").click();
         $("#post form").submit();
         equals($("#post").html(), "POST", "Should be POST");
-        
+
         $("#put").dblclick();
         $("#put form").submit();
         equals($("#put").html(), "PUT", "Should be PUT");
-    });
 
+    });
 });
 
 </script>
-  
+
 </head>
 <body>
-  
+
  <h1>Jeditable unit tests</h1>
  <h2 id="banner"></h2>
  <h2 id="userAgent"></h2>
@@ -204,5 +216,6 @@ $(document).ready(function() {
  <div id="select">Select B</div>
  <div id="callback">Here be dragons.</div>
  <div id="function">Here be dragons.</div>
+ <div id="differentId" data-model-id="3">Here be dragons.</div>
 </body>
 </html>


### PR DESCRIPTION
I've added another setting called `idattr`. It instructs the plugin to look at a specific attribute for its `id` value. It allowed me to put the id in the `data-model-id` attribute, and use that, since on some of my pages, those ids might conflict when I have more than one model on the page.

```
$("#differentId").editable("id.php", {
    submit  : "OK",
    idattr: 'data-model-id',
});
```

 And the markup:

```
<p id="differentId" data-model-id="3">Now id will be 3</p>
```
