### PR TITLE
Trigger custom input reset when reset function is called

### DIFF
--- a/jquery.jeditable.js
+++ b/jquery.jeditable.js
@@ -387,6 +387,12 @@
                         if (settings.tooltip) {
                             $(self).attr('title', settings.tooltip);                
                         }
+                        if ($.isFunction($.editable.types[settings.type].reset)) {
+                            var reset = $.editable.types[settings.type].reset;
+                        } else {
+                            var reset = $.editable.types['defaults'].reset;
+                        }
+                        reset.apply(form, [settings, self]);
                     }                    
                 }
             };            


### PR DESCRIPTION
I have a custom input with a custom cancel button, and when I called reset on the jeditable it wasn't calling the reset on my custom input. I think this change does that now but I doubt it's the best way to do it, just wanted to suggest it. Thanks for the project btw!
