### PR TITLE
Added intercept function, which is useful for handling JSON responses.

### DIFF
--- a/jquery.jeditable.js
+++ b/jquery.jeditable.js
@@ -91,6 +91,7 @@
         var reset    = $.editable.types[settings.type].reset 
                     || $.editable.types['defaults'].reset;
         var callback = settings.callback || function() { };
+        var intercept = settings.intercept || function(s) { return s; };
         var onedit   = settings.onedit   || function() { }; 
         var onsubmit = settings.onsubmit || function() { };
         var onreset  = settings.onreset  || function() { };
@@ -343,6 +344,7 @@
                                   dataType: 'html',
                                   url     : settings.target,
                                   success : function(result, status) {
+                                      result = intercept.apply(self,[result]);
                                       if (ajaxoptions.dataType == 'html') {
                                         $(self).html(result);
                                       }


### PR DESCRIPTION
Useful when you want to post-process the returned json data before it hits the page.

For example, your server returns the following json string: { "status": 1, "result": "value to be displayed", "other": "some other data" }, and you would like to process the "status" and "other" fields, and display the "result" field in the jeditable input field.

In your own code, you can do something like the following:

``` javascript
$(some_field).editable(
 '/some_url_on_your_server',
 {
     indicator : "<img src='/images/spinner.gif'>",
     tooltip: "Click to edit.",
     indicator: "Saving...",
     onblur: "submit",
     intercept: function (jsondata) {
         obj = jQuery.parseJSON(jsondata);
         // do something with obj.status and obj.other
         return(obj.result);
     }
}
```

From: http://stackoverflow.com/a/4611865/106778
