### PR TITLE
Type text attribute to the default input fields

### DIFF
--- a/jquery.jeditable.js
+++ b/jquery.jeditable.js
@@ -451,7 +451,7 @@
             },
             text: {
                 element : function(settings, original) {
-                    var input = $('<input />');
+                    var input = $('<input type="text" />');
                     if (settings.width  != 'none') { input.attr('width', settings.width);  }
                     if (settings.height != 'none') { input.attr('height', settings.height); }
                     /* https://bugzilla.mozilla.org/show_bug.cgi?id=236791 */


### PR DESCRIPTION
Default input text field didn't have the type attribute defined. This
caused problems with Bootstrap and several CSS styles that needed the
type="text" explicitly defined.
