### PR TITLE
HTML5 form plugin, validation constraints & WAI-ARIA/accessibility

### DIFF
--- a/contributed/jquery.jeditable.html5.js
+++ b/contributed/jquery.jeditable.html5.js
@@ -17,7 +17,7 @@
     $.fn.editableAriaShim = function () {
         //$.log('WAI-ARIA shim..');
 
-        $(this).attr({
+        this.attr({
             role: 'button',
             tabindex: 0
             //, title: 'Editable' -- See 'tooltip' below.
@@ -32,7 +32,15 @@
     // Accessibility - there should be a default value for the title/ tooltip.
     $.fn.editable.defaults.tooltip = 'Click to edit'; //$.fn.editable.defaults.placeholder
 
+    // Shim - $(sel).checkValidity()
+    if (! $.fn.checkValidity) {
+        $.fn.checkValidity = function () {
+            var inp = this[0];
+            return inp ? inp.checkValidity() : null;
+        };
+    }
 
+    // Type = text : With HTML5 attributes.
     $.editable.addInputType('html5_text', {
         element: function (settings, original) {
             var input = $('<input />').attr({
@@ -56,14 +64,7 @@
         }
     });
 
-$.editable.addInputType('unsigned_integer', {
-  element: function (settings, original) {
-    var input = $('<input type="number" min="0" max="10" step="1">');
-    $(this).append(input);
-    return input;
-  }
-});
-
+// Type = number.
 $.editable.addInputType('number', {
   element: function (settings, original) {
     var input = $('<input />').attr({
@@ -81,6 +82,16 @@ $.editable.addInputType('number', {
   }
 });
 
+// Deprecated.
+$.editable.addInputType('unsigned_integer', {
+  element: function (settings, original) {
+    var input = $('<input type="number" min="0" max="10" step="1">');
+    $(this).append(input);
+    return input;
+  }
+});
+
+// Type = range : Not usable.
 /*$.editable.addInputType('range', {
   element: function (settings, original) {
     var input = $('<input />').attr({
@@ -97,6 +108,7 @@ $.editable.addInputType('number', {
   }
 });*/
 
+// Type = email
 $.editable.addInputType('email', {
   element: function (settings, original) {
     var input = $('<input />').attr({
@@ -110,6 +122,7 @@ $.editable.addInputType('email', {
   }
 });
 
+// Type = url
 $.editable.addInputType('url', {
   element: function (settings, original) {
     var input = $('<input />').attr({

--- a/contributed/jquery.jeditable.html5.js
+++ b/contributed/jquery.jeditable.html5.js
@@ -26,7 +26,6 @@
         return this; //<--jquery object - chaining.
     };
 
-
     // Keyboard accessibility - use mouse click OR press any key to enable editing.
     $.fn.editable.defaults.event = 'click.editable keydown.editable';
 
@@ -42,7 +41,7 @@
                 // disabled -- Not relevant.
                 // readonly -- Not relevant.
                 //autocomplete: settings.autocomplete, -- Todo.
-                inputmode: settings.input.mode,
+                inputmode: settings.inputmode,
                 list: settings.list,
                 maxlength: settings.maxlength,
                 pattern: settings.pattern,

--- a/contributed/jquery.jeditable.html5.js
+++ b/contributed/jquery.jeditable.html5.js
@@ -40,6 +40,16 @@
         };
     }
 
+    var _supportInType = function (type) {
+        var i = document.createElement('input');
+        i.setAttribute('type', type);
+        return i.type !== 'text' ? type : 'text';
+
+        //return i.type !== 'text';
+        //return ! navigator.userAgent.match(/MSIE/);
+    };
+    //$.fn.supportInType = _supportInType;
+
     // Type = text : With HTML5 attributes.
     $.editable.addInputType('html5_text', {
         element: function (settings, original) {
@@ -75,7 +85,7 @@ $.editable.addInputType('number', {
         max : settings.max,
         step: settings.step,
         title: settings.html5_error_text,
-        type: 'number'
+        type: _supportInType('number') //? 'number' : 'text'
     });
     $(this).append(input);
     return input;
@@ -101,7 +111,7 @@ $.editable.addInputType('unsigned_integer', {
         min : settings.min,
         max : settings.max,
         step: settings.step,
-        type: 'range'
+        type: _supportInType('range')
     });
     $(this).append(input);
     return input;
@@ -115,7 +125,7 @@ $.editable.addInputType('email', {
         // pattern -- Not useful.
         maxlength: settings.maxlength,
         placeholder: settings.html5_placeholder,
-        type: 'email'
+        type: _supportInType('email') //? 'email' : 'text'
     });
     $(this).append(input);
     return input;
@@ -130,7 +140,7 @@ $.editable.addInputType('url', {
         pattern: settings.pattern,
         placeholder: settings.html5_placeholder,
         title: settings.html5_error_text,
-        type: 'url'
+        type: _supportInType('url') //? 'url' : 'text'
     });
     $(this).append(input);
     return input;

--- a/contributed/jquery.jeditable.html5.js
+++ b/contributed/jquery.jeditable.html5.js
@@ -15,8 +15,6 @@
 
     // Keyboard accessibility/WAI-ARIA - allow users to navigate to an editable element using TAB/Shift+TAB.
     $.fn.editableAriaShim = function () {
-        //$.log('WAI-ARIA shim..');
-
         this.attr({
             role: 'button',
             tabindex: 0
@@ -44,11 +42,7 @@
         var i = document.createElement('input');
         i.setAttribute('type', type);
         return i.type !== 'text' ? type : 'text';
-
-        //return i.type !== 'text';
-        //return ! navigator.userAgent.match(/MSIE/);
     };
-    //$.fn.supportInType = _supportInType;
 
     // Type = text : With HTML5 attributes.
     $.editable.addInputType('html5_text', {
@@ -85,17 +79,8 @@ $.editable.addInputType('number', {
         max : settings.max,
         step: settings.step,
         title: settings.html5_error_text,
-        type: _supportInType('number') //? 'number' : 'text'
+        type: _supportInType('number')
     });
-    $(this).append(input);
-    return input;
-  }
-});
-
-// Deprecated.
-$.editable.addInputType('unsigned_integer', {
-  element: function (settings, original) {
-    var input = $('<input type="number" min="0" max="10" step="1">');
     $(this).append(input);
     return input;
   }
@@ -125,7 +110,7 @@ $.editable.addInputType('email', {
         // pattern -- Not useful.
         maxlength: settings.maxlength,
         placeholder: settings.html5_placeholder,
-        type: _supportInType('email') //? 'email' : 'text'
+        type: _supportInType('email')
     });
     $(this).append(input);
     return input;
@@ -140,7 +125,7 @@ $.editable.addInputType('url', {
         pattern: settings.pattern,
         placeholder: settings.html5_placeholder,
         title: settings.html5_error_text,
-        type: _supportInType('url') //? 'url' : 'text'
+        type: _supportInType('url')
     });
     $(this).append(input);
     return input;

--- a/contributed/jquery.jeditable.html5.js
+++ b/contributed/jquery.jeditable.html5.js
@@ -1,0 +1,129 @@
+/*
+ * HTML5 and accessibility/WAI-ARIA support for Jeditable.
+ *
+ * Copyright (c) 2013 Nick Freear, The Open University.
+ *
+ * Licensed under the MIT license:
+ *   http://www.opensource.org/licenses/mit-license.php
+ */
+
+/*jslint browser: true, indent: 4 */
+
+(function ($) {
+
+    'use strict';
+
+    // Keyboard accessibility/WAI-ARIA - allow users to navigate to an editable element using TAB/Shift+TAB.
+    $.fn.editableAriaShim = function () {
+        //$.log('WAI-ARIA shim..');
+
+        $(this).attr({
+            role: 'button',
+            tabindex: 0
+            //, title: 'Editable' -- See 'tooltip' below.
+            //, 'aria-label':''
+        });
+        return this; //<--jquery object - chaining.
+    };
+
+
+    // Keyboard accessibility - use mouse click OR press any key to enable editing.
+    $.fn.editable.defaults.event = 'click.editable keydown.editable';
+
+    // Accessibility - there should be a default value for the title/ tooltip.
+    $.fn.editable.defaults.tooltip = 'Click to edit'; //$.fn.editable.defaults.placeholder
+
+
+    $.editable.addInputType('html5_text', {
+        element: function (settings, original) {
+            var input = $('<input />').attr({
+                // required: settings.required ? 'required' : '', -- See below.
+                // autofocus -- Not relevant for Jeditable.
+                // disabled -- Not relevant.
+                // readonly -- Not relevant.
+                //autocomplete: settings.autocomplete, -- Todo.
+                inputmode: settings.input.mode,
+                list: settings.list,
+                maxlength: settings.maxlength,
+                pattern: settings.pattern,
+                placeholder: settings.html5_placeholder, // Parameter name conflict - add 'html5_'.
+                title: settings.html5_error_text,
+                type: 'text'
+            });
+            if (settings.required) { input.attr('required', ''); } // Is this relevant to Jeditable? Probably.
+
+            $(this).append(input);
+            return input;
+        }
+    });
+
+$.editable.addInputType('unsigned_integer', {
+  element: function (settings, original) {
+    var input = $('<input type="number" min="0" max="10" step="1">');
+    $(this).append(input);
+    return input;
+  }
+});
+
+$.editable.addInputType('number', {
+  element: function (settings, original) {
+    var input = $('<input />').attr({
+        maxlength: settings.maxlength,
+        //pattern: settings.pattern, -- Does not apply to 'number' (but may be useful if 'number' is not supported).
+        placeholder: settings.html5_placeholder,
+        min : settings.min,
+        max : settings.max,
+        step: settings.step,
+        title: settings.html5_error_text,
+        type: 'number'
+    });
+    $(this).append(input);
+    return input;
+  }
+});
+
+/*$.editable.addInputType('range', {
+  element: function (settings, original) {
+    var input = $('<input />').attr({
+        maxlength: settings.maxlength,
+        pattern: settings.pattern,
+        placeholder: settings.html5_placeholder,
+        min : settings.min,
+        max : settings.max,
+        step: settings.step,
+        type: 'range'
+    });
+    $(this).append(input);
+    return input;
+  }
+});*/
+
+$.editable.addInputType('email', {
+  element: function (settings, original) {
+    var input = $('<input />').attr({
+        // pattern -- Not useful.
+        maxlength: settings.maxlength,
+        placeholder: settings.html5_placeholder,
+        type: 'email'
+    });
+    $(this).append(input);
+    return input;
+  }
+});
+
+$.editable.addInputType('url', {
+  element: function (settings, original) {
+    var input = $('<input />').attr({
+        maxlength: settings.maxlength,
+        pattern: settings.pattern,
+        placeholder: settings.html5_placeholder,
+        title: settings.html5_error_text,
+        type: 'url'
+    });
+    $(this).append(input);
+    return input;
+  }
+});
+
+
+})(jQuery);

--- a/contributed/jquery.jeditable.html5.js
+++ b/contributed/jquery.jeditable.html5.js
@@ -36,7 +36,7 @@
     if (! $.fn.checkValidity) {
         $.fn.checkValidity = function () {
             var inp = this[0];
-            return inp ? inp.checkValidity() : null;
+            return inp && typeof inp.checkValidity==="function" ? inp.checkValidity() : null;
         };
     }
 

--- a/html5.html
+++ b/html5.html
@@ -1,0 +1,97 @@
+<!doctype html><html lang="en">
+<meta charset="utf-8" />
+<title>Jeditable HTML5 Input Types Demo</title>
+<meta name="generator" content="Mephisto" />
+<link href="http://www.appelsiini.net/stylesheets/main2.css" rel="stylesheet" />
+<link rel="alternate" type="application/atom+xml" href="http://feeds.feedburner.com/tuupola" title="Atom feed" />
+<script src="/mint/?js"></script>
+<!--<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.2.6/jquery.min.js" charset="utf-8"></script>-->
+<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.4/jquery.min.js" charset="utf-8"></script>
+
+<script src="jquery.jeditable.js"></script>
+<script src="contributed/jquery.jeditable.html5.js" ></script>
+
+<script>
+$(document).ready(function () {
+
+  // Keyboard accessibility.
+  $(".editable").editableAriaShim();
+
+  $(".number").editable("php/echo.php", {
+    type: "number",
+    tooltip: "Click to edit: number",
+    html5_placeholder: "0",
+    html5_error_text: "Enter a number between 0 and 10",
+    min: 0,
+    max: 10,
+    step: 1
+  });
+
+  $(".email").editable("php/echo.php", {
+    type: "email",
+    tooltip: "Click to edit: email"
+  });
+
+  $(".editable.text").editable("php/echo.php", {
+    type: "html5_text",
+    tooltip: "Click to edit: username",
+    html5_error_text: "Enter a lower-case name, optionally ending a number. No spaces.",
+    pattern: "[a-z]+\\d?",
+    required: true
+  });
+});
+</script>
+
+
+<body>
+  <div id="wrap"> 
+    <div id="header">
+      <p>
+        <h1>Jeditable</h1><br />
+        <small>Edit in place plugin for jQuery.</small>
+        <ul id="nav">
+          <li id="first"><a href="/" class="active">weblog</a></li>
+          <li><a href="/projects" class="last">projects</a></li>
+          <!--
+          <li><a href="/cv" class="last">cv</a></li>
+        -->
+        </ul>
+      </p>
+    </div>
+    <div id="content">
+
+    <p>You might also want to check <a href="default.html">default inputs demo</a>.</p>
+
+    <div class="entry">
+
+      <h2>HTML5</h2>
+
+      <p>Some useful introductions to HTML5 forms:
+        <a href="http://diveintohtml5.info/forms.html">Dive into HTML5: Forms</a> and
+        <a href="http://whatwg.org/specs/web-apps/current-work/multipage/the-input-element.html">HTML5: The <code>input</code> element</a>
+
+      <h3>Number type</h3>
+      <p class="editable number" id="number" >-2.06</p>
+
+      <h3>Email type</h3>
+      <p class="editable email" id="email" >Joe+TAG1@example</p>
+
+      <h3>HTML5 text</h3>
+      <p class="editable text" id="username" >user5</p>
+
+
+    </div>
+
+    <div id="sidebar">
+    </div>
+  
+  <div id="footer">
+  </div>
+
+  <script src="http://www.google-analytics.com/urchin.js"></script>
+  <script>
+    _uacct = "UA-190966-1";
+    urchinTracker();
+  </script>
+</body>
+</html>

--- a/php/config.php
+++ b/php/config.php
@@ -6,6 +6,7 @@ try {
     $dbh = new PDO('sqlite:/tmp/editable.sqlite');
 } catch(PDOException $e) {
     print $e->getMessage();
+    exit(-1);
 }
 
 /* Create table for storing example data. */

--- a/php/echo.php
+++ b/php/echo.php
@@ -2,7 +2,7 @@
 
 /* Does not save anything. Just echoes back for demonstration purposes. */
 
-$renderer = isset($_GET['renderer']) ?  $_GET['renderer'] : $_POST['renderer'];
+$renderer = isset($_GET['renderer']) ?  $_GET['renderer'] : (isset($_POST['renderer']) ? $_POST['renderer'] : NULL);
 if ('textile' == $renderer) {
     require_once './Textile.php';
     $t = new Textile();

--- a/tests/echo.php
+++ b/tests/echo.php
@@ -2,7 +2,7 @@
 
 /* $Id: echo.php 117 2007-03-02 16:16:08Z tuupola $ */
 
-$renderer = isset($_GET['renderer']) ?  $_GET['renderer'] : $_POST['renderer'];
+$renderer = isset($_GET['renderer']) ?  $_GET['renderer'] : (isset($_POST['renderer']) ? $_POST['renderer'] : NULL);
 if ('textile' == $renderer) {
     require_once './Textile.php';
     $t = new Textile();

--- a/tests/index.html
+++ b/tests/index.html
@@ -237,20 +237,21 @@ $(document).ready(function() {
         equals($("#h5-number input").attr("type"), "number", "Type should be `number`");
         equals($("#h5-number input").attr("min"), "0", "Attribute `min` should be 0");
         equals($("#h5-number input").val(), "-2.06", "Value should be -2.06");
-        equals(typeof document.querySelector("#h5-number input").checkValidity, "function", "`\x3Cinput>.checkValidity` is a function");
-        equals(document.querySelector("#h5-number input").checkValidity(), false, "`\x3Cinput>.checkValidity()` should return false");
+
+        equals(typeof $.fn.checkValidity, "function", "`$.fn.checkValidity` is a function");
+        equals($("#h5-number input").checkValidity(), false, "`$(selector).checkValidity()` should return false");
         $("#h5-number form").submit();
 
         $("#h5-email").trigger("click");
         equals($("#h5-email input").attr("type"), "email", "Type should be `email`");
-        equals($("#h5-email input")[0].checkValidity(), true, "`checkValidity()` should return true");
+        equals($("#h5-email input").checkValidity(), true, "`$(selector).checkValidity()` should return true");
         $("#h5-email form").submit();
 
         $("#h5-text").trigger("click");
         equals($("#h5-text input").attr("type"), "text", "Type should be `text`");
         equals($("#h5-text input").attr("required"), '', "Attribute `required` should be '' (empty)");
-        equals(typeof $.fn.checkValidity, "function", "`$.fn.checkValidity` is a function");
-        equals($("#h5-text input").checkValidity(), true, "`$(selector).checkValidity()` should return true");
+        equals(typeof document.querySelector("#h5-text input").checkValidity, "function", "`\x3Cinput>.checkValidity` is a function");
+        equals(document.querySelector("#h5-text input").checkValidity(), true, "`\x3Cinput>.checkValidity()` should return true");
         $("#h5-text form").submit();
     });
 
@@ -263,10 +264,12 @@ $(document).ready(function() {
   
 </head>
 <body>
-  
+
  <h1>Jeditable unit tests</h1>
  <h2 id="banner"></h2>
  <h2 id="userAgent"></h2>
+
+<!--[if IE]><p style="color:red">Most HTML5 unit tests will NOT pass with Internet Explorer (especially MSIE &lt; 10)<![endif]-->
 
  <ol id="tests"></ol>
 

--- a/tests/index.html
+++ b/tests/index.html
@@ -3,10 +3,13 @@
 <html>
 <head>
 <title>Jeditable Unit Tests</title>
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.2.6/jquery.min.js" type="text/javascript" charset="utf-8"></script>
+<!--<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.2.6/jquery.min.js" type="text/javascript" charset="utf-8"></script>-->
+<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.4/jquery.min.js" type="text/javascript" charset="utf-8"></script>
 <link rel="stylesheet" href="testsuite.css" type="text/css" media="screen" />
 <script type="text/javascript" src="testrunner.js"></script>
 <script type="text/javascript" src="../jquery.jeditable.js"></script>
+
+<script type="text/javascript" src="../contributed/jquery.jeditable.html5.js"></script>
 <script>
 $(document).ready(function() {
     
@@ -65,7 +68,33 @@ $(document).ready(function() {
     }, {
         submit  : "OK"
     });
-    
+
+
+    $(".editable").editableAriaShim();
+
+    $("#h5-number").editable("echo.php", {
+        type: "number",
+        tooltip: "Click to edit: number",
+        html5_placeholder: "0",
+        html5_error_text: "Enter a number between 0 and 10",
+        min: 0,
+        max: 10,
+        step: 1
+    });
+
+    $("#h5-email").editable("echo.php", {
+        type: "email",
+        tooltip: "Click to edit: email"
+    });
+
+    $("#h5-text").editable("echo.php", {
+        type: "html5_text",
+        tooltip: "Click to edit: username",
+        html5_error_text: "Enter a lower-case name, optionally ending a number. No spaces.",
+        pattern: "[a-z]+\\d?",
+        required: true
+    });
+
     module("CORE");    
 
     test("Event triggers", function() {
@@ -184,6 +213,41 @@ $(document).ready(function() {
         equals($("#put").html(), "PUT", "Should be PUT");
     });
 
+
+    module("HTML5");
+
+    test("Keyboard accessibility", function () {
+        equals($(".editable").attr("role"), "button", "WAI-ARIA role should be button");
+        equals($(".editable").attr("tabindex"), "0", "Tabindex should be 0");
+        $("#h5-number").trigger("click");
+        ok($("#h5-number form").size() == 1, "Click event should trigger Jeditable.");
+        $("#h5-number form").submit();
+        ok($("#h5-number form").size() == 0, "After submit should go back to normal.");
+        $("#h5-number").trigger("keydown");
+        ok($("#h5-number form").size() == 1, "Keydown event should trigger Jeditable.");
+        $("#h5-number form").submit();
+        ok($("#h5-number form").size() == 0, "After submit should go back to normal.");
+    });
+
+    test("HTML5 input types", function () {
+        $("#h5-number").trigger("click");
+        equals($("#h5-number input").attr("type"), "number", "Type should be number");
+        equals($("#h5-number input").attr("min"), "0", "Min should be 0");
+        equals($("#h5-number input").val(), "-2.06", "Value should be -2.06");
+        equals(document.querySelector("#h5-number input").checkValidity(), false, "checkValidity() should be false");
+        $("#h5-number form").submit();
+
+        $("#h5-email").trigger("click");
+        equals($("#h5-email input").attr("type"), "email", "Type should be email");
+        equals($("#h5-email input")[0].checkValidity(), true, "checkValidity() should be true");
+        $("#h5-email form").submit();
+
+        $("#h5-text").trigger("click");
+        equals($("#h5-text input").attr("type"), "text", "Type should be text");
+        equals($("#h5-text input").attr("required"), '', "Required should be '' (empty string)");
+        equals($("#h5-text input").checkValidity(), true, "checkValidity() should be true");
+        $("#h5-text form").submit();
+    });
 });
 
 </script>
@@ -204,5 +268,10 @@ $(document).ready(function() {
  <div id="select">Select B</div>
  <div id="callback">Here be dragons.</div>
  <div id="function">Here be dragons.</div>
+
+ <div id="h5-number" class="editable">-2.06</div>
+ <div id="h5-email" class="editable">Joe+TAG1@example</div>
+ <div id="h5-text" class="editable">user5</div>
+
 </body>
 </html>

--- a/tests/index.html
+++ b/tests/index.html
@@ -95,6 +95,7 @@ $(document).ready(function() {
         required: true
     });
 
+
     module("CORE");    
 
     test("Event triggers", function() {
@@ -217,8 +218,10 @@ $(document).ready(function() {
     module("HTML5");
 
     test("Keyboard accessibility", function () {
-        equals($(".editable").attr("role"), "button", "WAI-ARIA role should be button");
-        equals($(".editable").attr("tabindex"), "0", "Tabindex should be 0");
+        /*( isObj($.fn.editableAriaShim, function(){}, "Is a function, v1"); )*/
+        equals(typeof $.fn.editableAriaShim, "function", "`$.fn.editableAriaShim` is a function()");
+        equals($(".editable").attr("role"), "button", "WAI-ARIA `role` should be `button`");
+        equals($(".editable").attr("tabindex"), "0", "Attribute `tabindex` should be 0");
         $("#h5-number").trigger("click");
         ok($("#h5-number form").size() == 1, "Click event should trigger Jeditable.");
         $("#h5-number form").submit();
@@ -231,25 +234,31 @@ $(document).ready(function() {
 
     test("HTML5 input types", function () {
         $("#h5-number").trigger("click");
-        equals($("#h5-number input").attr("type"), "number", "Type should be number");
-        equals($("#h5-number input").attr("min"), "0", "Min should be 0");
+        equals($("#h5-number input").attr("type"), "number", "Type should be `number`");
+        equals($("#h5-number input").attr("min"), "0", "Attribute `min` should be 0");
         equals($("#h5-number input").val(), "-2.06", "Value should be -2.06");
-        equals(document.querySelector("#h5-number input").checkValidity(), false, "checkValidity() should be false");
+        equals(typeof document.querySelector("#h5-number input").checkValidity, "function", "`\x3Cinput>.checkValidity` is a function");
+        equals(document.querySelector("#h5-number input").checkValidity(), false, "`\x3Cinput>.checkValidity()` should return false");
         $("#h5-number form").submit();
 
         $("#h5-email").trigger("click");
-        equals($("#h5-email input").attr("type"), "email", "Type should be email");
-        equals($("#h5-email input")[0].checkValidity(), true, "checkValidity() should be true");
+        equals($("#h5-email input").attr("type"), "email", "Type should be `email`");
+        equals($("#h5-email input")[0].checkValidity(), true, "`checkValidity()` should return true");
         $("#h5-email form").submit();
 
         $("#h5-text").trigger("click");
-        equals($("#h5-text input").attr("type"), "text", "Type should be text");
-        equals($("#h5-text input").attr("required"), '', "Required should be '' (empty string)");
-        equals($("#h5-text input").checkValidity(), true, "checkValidity() should be true");
+        equals($("#h5-text input").attr("type"), "text", "Type should be `text`");
+        equals($("#h5-text input").attr("required"), '', "Attribute `required` should be '' (empty)");
+        equals(typeof $.fn.checkValidity, "function", "`$.fn.checkValidity` is a function");
+        equals($("#h5-text input").checkValidity(), true, "`$(selector).checkValidity()` should return true");
         $("#h5-text form").submit();
     });
-});
 
+    // Hack: add IDs for easy reference.
+    $("#tests > li").each(function (i, el) {
+        el.id = "qt-" + i;
+    });
+});
 </script>
   
 </head>

--- a/tests/testsuite.css
+++ b/tests/testsuite.css
@@ -6,7 +6,10 @@ h2 { padding: 10px; background-color: #eee; color: black; margin: 0; font-size: 
 
 .pass { color: green; } 
 .fail { color: red; } 
-p.result { margin-left: 1em; }
+.editable :valid { border-color: green; }
+:focus:invalid { border-color: red; }
+
+p.result, div[id] { margin-left: 1em; }
 
 #banner { height: 2em; border-bottom: 1px solid white; }
 h2.pass { background-color: green; }


### PR DESCRIPTION
Hi Adell,

Please pull (see bug #84):
- Added a Javascript plugin: `contributed/jquery.jeditable.html5.js`
- Added tests: `tests/index.html`
- Added a demo page: `html5.html`

Additional supported types (so far):
- "html5_text" (`<input type=text >`), "number", "email", "url".

Additional configuration properties:
- inputmode, list, maxlength, pattern, required, min, max, step, html5_placeholder, html5_error_text.

Additional function:
- `$(selector).editableAriaShim()`

HTML5 forms shim:
- `$(selector).checkValidity()`

Many thanks, Nick
