### PR TITLE
Fix image url

### DIFF
--- a/css/jquery.autocomplete.css
+++ b/css/jquery.autocomplete.css
@@ -35,7 +35,7 @@
 }
 
 .ac_loading {
-	background: white url('indicator.gif') right center no-repeat;
+	background: white url('../img/indicator.gif') right center no-repeat;
 }
 
 .ac_odd {


### PR DESCRIPTION
The invalid image link breaks when trying to use the example project. This resolves the 404 error
