### PR TITLE
Add sort-option, fix key for selected, and fix double submit

### DIFF
--- a/src/jquery.jeditable.js
+++ b/src/jquery.jeditable.js
@@ -231,6 +231,7 @@
 
                 // timeout function
                 var t;
+                var is_submitting = false;
 
                 if (settings.loadurl) {
                     t = self.setTimeout(function() {
@@ -339,12 +340,20 @@
 
                 form.submit(function(e) {
 
+                    /* Do no submit. */
+                    e.preventDefault();
+                    e.stopPropagation();
+
+                    if (is_submitting) {
+                        console.log("...we are already submitting .. stop!");
+                        return false;
+                    } else {
+                        is_submitting = true;
+                    }
+
                     if (t) {
                         self.clearTimeout(t);
                     }
-
-                    /* Do no submit. */
-                    e.preventDefault();
 
                     /* Call before submit hook. */
                     /* If it returns false abort submitting. */

--- a/src/jquery.jeditable.js
+++ b/src/jquery.jeditable.js
@@ -231,7 +231,7 @@
 
                 // timeout function
                 var t;
-                var is_submitting = false;
+                var isSubmitting = false;
 
                 if (settings.loadurl) {
                     t = self.setTimeout(function() {
@@ -344,11 +344,11 @@
                     e.preventDefault();
                     e.stopPropagation();
 
-                    if (is_submitting) {
-                        console.log("...we are already submitting .. stop!");
+                    if (isSubmitting) {
+                        console.warn('...we are already submitting .. stop!');
                         return false;
                     } else {
-                        is_submitting = true;
+                        isSubmitting = true;
                     }
 
                     if (t) {
@@ -677,7 +677,7 @@ var _supportInType = function (type) {
                     for (key in json) {
                         tuples.push([key, json[key]]); // Store: [key, value]
                     }
-                    if (settings.sort_select_options) {
+                    if (settings.sortSelectOptions) {
                         // sort it
                         tuples.sort(function (a, b) {
                             a = a[1];
@@ -793,7 +793,7 @@ var _supportInType = function (type) {
         loadtype   : 'GET',
         loadtext   : 'Loading...',
         placeholder: 'Click to edit',
-        sort_select_options: false,
+        sortSelectOptions: false,
         loaddata   : {},
         submitdata : {},
         ajaxoptions: {}

--- a/src/jquery.jeditable.js
+++ b/src/jquery.jeditable.js
@@ -688,14 +688,14 @@ var _supportInType = function (type) {
 
                         if (key !== 'selected') {
                             option = $('<option />').val(key).append(value);
-                        }
 
-                        // add the selected prop if it's the same as original or if the key is 'selected'
-                        if (key === 'selected' || key === $.trim(original.revert)) {
-                            $(option).prop('selected', 'selected');
-                        }
+                            // add the selected prop if it's the same as original or if the key is 'selected'
+                            if (json['selected'] === key || key === $.trim(original.revert)) {
+                                $(option).prop('selected', 'selected');
+                            }
 
-                        $(this).find('select').append(option);
+                            $(this).find('select').append(option);
+                        }
                     }
 
                     // submit on change if no submit button defined

--- a/src/jquery.jeditable.js
+++ b/src/jquery.jeditable.js
@@ -668,13 +668,14 @@ var _supportInType = function (type) {
                     for (key in json) {
                         tuples.push([key, json[key]]); // Store: [key, value]
                     }
-                    // sort it
-                    tuples.sort(function(a, b) {
-                        a = a[1];
-                        b = b[1];
-                        return a < b ? -1 : (a > b ? 1 : 0);
-                    });
-
+                    if (settings.sort_select_options) {
+                        // sort it
+                        tuples.sort(function (a, b) {
+                            a = a[1];
+                            b = b[1];
+                            return a < b ? -1 : (a > b ? 1 : 0);
+                        });
+                    }     
                     // now add the options to our select
                     var option;
                     for (var i = 0; i < tuples.length; i++) {
@@ -783,6 +784,7 @@ var _supportInType = function (type) {
         loadtype   : 'GET',
         loadtext   : 'Loading...',
         placeholder: 'Click to edit',
+        sort_select_options: false,
         loaddata   : {},
         submitdata : {},
         ajaxoptions: {}

--- a/src/jquery.jeditable.js
+++ b/src/jquery.jeditable.js
@@ -684,7 +684,7 @@ var _supportInType = function (type) {
                             b = b[1];
                             return a < b ? -1 : (a > b ? 1 : 0);
                         });
-                    }     
+                    }
                     // now add the options to our select
                     var option;
                     for (var i = 0; i < tuples.length; i++) {
@@ -699,7 +699,7 @@ var _supportInType = function (type) {
                             option = $('<option />').val(key).append(value);
 
                             // add the selected prop if it's the same as original or if the key is 'selected'
-                            if (json['selected'] === key || key === $.trim(original.revert)) {
+                            if (json.selected === key || key === $.trim(original.revert)) {
                                 $(option).prop('selected', 'selected');
                             }
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -34,7 +34,7 @@ QUnit.test("Default: NOT Sorting select options", function(assert) {
     $('#select-tester').editable('http://bla', {
         type: 'select',
         data: {"E": "Letter E", 'F': 'Letter F', 'D': 'Letter Disk'},
-        selected: 'Letter F'
+        selected: 'F'
     });
 
     assert.equal( $( "#select-tester").attr('title'), "Click to edit", "Editable enabled: it sets the title" );
@@ -54,7 +54,7 @@ QUnit.test("Default: Sorting select options", function(assert) {
     $('#select-sorted-tester').editable('http://bla', {
         type: 'select',
         data: {"E": "Letter E", 'F': 'Letter F', 'D': 'Letter Disk'},
-        selected: 'Letter F'
+        selected: 'F'
     });
     assert.equal( $( "#select-sorted-tester").attr('title'), "Click to edit", "Editable enabled: it sets the title" );
     $('#select-sorted-tester').click();
@@ -65,3 +65,33 @@ QUnit.test("Default: Sorting select options", function(assert) {
 
     assert.deepEqual(options_list, ["Letter Disk", "Letter E", "Letter F"], "It does sort the given options list");
 });
+QUnit.module("select-boxes setting selected");
+QUnit.test("Explicitly setting a selected option", function(assert) {
+    elem.append( "<span id='selected-tester'>Letter F</span>" );
+
+    $.fn.editable.defaults.sort_select_options = false;
+
+    $('#selected-tester').editable('http://bla', {
+        type: 'select',
+        data: {"E": "Letter E", "F": "Letter F", "D": "Letter Disk", "selected": "F"},
+    });
+
+    assert.equal( $( "#selected-tester").attr('title'), "Click to edit", "Editable enabled: it sets the title" );
+    $('#selected-tester').click();
+    assert.equal($('#selected-tester form select :selected').text(), 'Letter F', "Sets the correct value as selected")
+});
+QUnit.test("Not setting a selected option", function(assert) {
+    elem.append( "<span id='selected-tester'>Letter F</span>" );
+
+    $.fn.editable.defaults.sort_select_options = false;
+
+    $('#selected-tester').editable('http://bla', {
+        type: 'select',
+        data: {"E": "Letter E", "F": "Letter F", "D": "Letter Disk"},
+    });
+
+    assert.equal( $( "#selected-tester").attr('title'), "Click to edit", "Editable enabled: it sets the title" );
+    $('#selected-tester').click();
+    assert.equal($('#selected-tester form select :selected').text(), 'Letter E', "Selects the first option as selected?")
+});
+

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -67,7 +67,7 @@ QUnit.test('Default: Sorting select options', function(assert) {
 });
 QUnit.module('select-boxes setting selected');
 QUnit.test('Explicitly setting a selected option', function(assert) {
-    elem.append( "<span id='selected-tester'>Letter F</span>" );
+    elem.append( '<span id="selected-tester">Letter F</span>' );
 
     $.fn.editable.defaults.sortSelectOptions = false;
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -27,7 +27,7 @@ QUnit.test('Enable/disable/destroy', function(assert) {
 
 QUnit.module('select-boxes');
 QUnit.test('Default: NOT Sorting select options', function(assert) {
-    elem.append( "<span id='select-tester'>Letter F</span>" );
+    elem.append( '<span id="select-tester">Letter F</span>' );
 
     $.fn.editable.defaults.sortSelectOptions = false;
 
@@ -39,15 +39,15 @@ QUnit.test('Default: NOT Sorting select options', function(assert) {
 
     assert.equal( $('#select-tester').attr('title'), 'Click to edit', 'Editable enabled: it sets the title' );
     $('#select-tester').click();
-    assert.equal($('#select-tester form').length, 1, 'Clicking Editable adds inline form')
+    assert.equal($('#select-tester form').length, 1, 'Clicking Editable adds inline form');
 
-    var options_list = []
-    $('#select-tester option').each(function(name, val) { options_list.push(val.text); });
+    var optionsList = [];
+    $('#select-tester option').each(function(name, val) { optionsList.push(val.text); });
 
-    assert.deepEqual(options_list, ['Letter E', 'Letter F', 'Letter Disk'], 'Does not sort the given options-list');
+    assert.deepEqual(optionsList, ['Letter E', 'Letter F', 'Letter Disk'], 'Does not sort the given options-list');
 });
 QUnit.test('Default: Sorting select options', function(assert) {
-    elem.append( "<span id='select-sorted-tester'>Letter F</span>" );
+    elem.append( '<span id="select-sorted-tester">Letter F</span>' );
 
     $.fn.editable.defaults.sortSelectOptions = true;
 
@@ -60,10 +60,10 @@ QUnit.test('Default: Sorting select options', function(assert) {
     $('#select-sorted-tester').click();
     assert.equal($('#select-sorted-tester form').length, 1, 'Clicking Editable adds inline form');
 
-    var options_list = []
-    $('#select-sorted-tester option').each(function(name, val) { options_list.push(val.text); });
+    var optionsList = [];
+    $('#select-sorted-tester option').each(function(name, val) { optionsList.push(val.text); });
 
-    assert.deepEqual(options_list, ['Letter Disk', 'Letter E', 'Letter F'], 'It does sort the given options list');
+    assert.deepEqual(optionsList, ['Letter Disk', 'Letter E', 'Letter F'], 'It does sort the given options list');
 });
 QUnit.module('select-boxes setting selected');
 QUnit.test('Explicitly setting a selected option', function(assert) {
@@ -78,10 +78,10 @@ QUnit.test('Explicitly setting a selected option', function(assert) {
 
     assert.equal( $( '#selected-tester').attr('title'), 'Click to edit', 'Editable enabled: it sets the title' );
     $('#selected-tester').click();
-    assert.equal($('#selected-tester form select :selected').text(), 'Letter F', 'Sets the correct value as selected')
+    assert.equal($('#selected-tester form select :selected').text(), 'Letter F', 'Sets the correct value as selected');
 });
 QUnit.test('Not setting a selected option', function(assert) {
-    elem.append( "<span id='selected-tester'>Letter F</span>" );
+    elem.append( '<span id="selected-tester">Letter F</span>' );
 
     $.fn.editable.defaults.sortSelectOptions = false;
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -24,3 +24,44 @@ QUnit.test('Enable/disable/destroy', function(assert) {
     elem.editable().editable('destroy');
     assert.notOk(elem.data('event.editable'));
 });
+
+QUnit.module("select-boxes");
+QUnit.test("Default: NOT Sorting select options", function(assert) {
+    elem.append( "<span id='select-tester'>Letter F</span>" );
+
+    $.fn.editable.defaults.sort_select_options = false;
+
+    $('#select-tester').editable('http://bla', {
+        type: 'select',
+        data: {"E": "Letter E", 'F': 'Letter F', 'D': 'Letter Disk'},
+        selected: 'Letter F'
+    });
+
+    assert.equal( $( "#select-tester").attr('title'), "Click to edit", "Editable enabled: it sets the title" );
+    $('#select-tester').click();
+    assert.equal($('#select-tester form').length, 1, "Clicking Editable adds inline form")
+
+    var options_list = []
+    $('#select-tester option').each(function(name, val) { options_list.push(val.text); });
+
+    assert.deepEqual(options_list, ["Letter E", "Letter F", "Letter Disk"], "Does not sort the given options-list");
+});
+QUnit.test("Default: Sorting select options", function(assert) {
+    elem.append( "<span id='select-sorted-tester'>Letter F</span>" );
+
+    $.fn.editable.defaults.sort_select_options = true;
+
+    $('#select-sorted-tester').editable('http://bla', {
+        type: 'select',
+        data: {"E": "Letter E", 'F': 'Letter F', 'D': 'Letter Disk'},
+        selected: 'Letter F'
+    });
+    assert.equal( $( "#select-sorted-tester").attr('title'), "Click to edit", "Editable enabled: it sets the title" );
+    $('#select-sorted-tester').click();
+    assert.equal($('#select-sorted-tester form').length, 1, "Clicking Editable adds inline form")
+
+    var options_list = []
+    $('#select-sorted-tester option').each(function(name, val) { options_list.push(val.text); });
+
+    assert.deepEqual(options_list, ["Letter Disk", "Letter E", "Letter F"], "It does sort the given options list");
+});

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -25,73 +25,73 @@ QUnit.test('Enable/disable/destroy', function(assert) {
     assert.notOk(elem.data('event.editable'));
 });
 
-QUnit.module("select-boxes");
-QUnit.test("Default: NOT Sorting select options", function(assert) {
+QUnit.module('select-boxes');
+QUnit.test('Default: NOT Sorting select options', function(assert) {
     elem.append( "<span id='select-tester'>Letter F</span>" );
 
-    $.fn.editable.defaults.sort_select_options = false;
+    $.fn.editable.defaults.sortSelectOptions = false;
 
     $('#select-tester').editable('http://bla', {
         type: 'select',
-        data: {"E": "Letter E", 'F': 'Letter F', 'D': 'Letter Disk'},
+        data: {'E': 'Letter E', 'F': 'Letter F', 'D': 'Letter Disk'},
         selected: 'F'
     });
 
-    assert.equal( $( "#select-tester").attr('title'), "Click to edit", "Editable enabled: it sets the title" );
+    assert.equal( $('#select-tester').attr('title'), 'Click to edit', 'Editable enabled: it sets the title' );
     $('#select-tester').click();
-    assert.equal($('#select-tester form').length, 1, "Clicking Editable adds inline form")
+    assert.equal($('#select-tester form').length, 1, 'Clicking Editable adds inline form')
 
     var options_list = []
     $('#select-tester option').each(function(name, val) { options_list.push(val.text); });
 
-    assert.deepEqual(options_list, ["Letter E", "Letter F", "Letter Disk"], "Does not sort the given options-list");
+    assert.deepEqual(options_list, ['Letter E', 'Letter F', 'Letter Disk'], 'Does not sort the given options-list');
 });
-QUnit.test("Default: Sorting select options", function(assert) {
+QUnit.test('Default: Sorting select options', function(assert) {
     elem.append( "<span id='select-sorted-tester'>Letter F</span>" );
 
-    $.fn.editable.defaults.sort_select_options = true;
+    $.fn.editable.defaults.sortSelectOptions = true;
 
     $('#select-sorted-tester').editable('http://bla', {
         type: 'select',
-        data: {"E": "Letter E", 'F': 'Letter F', 'D': 'Letter Disk'},
+        data: {'E': 'Letter E', 'F': 'Letter F', 'D': 'Letter Disk'},
         selected: 'F'
     });
-    assert.equal( $( "#select-sorted-tester").attr('title'), "Click to edit", "Editable enabled: it sets the title" );
+    assert.equal( $('#select-sorted-tester').attr('title'), 'Click to edit', 'Editable enabled: it sets the title' );
     $('#select-sorted-tester').click();
-    assert.equal($('#select-sorted-tester form').length, 1, "Clicking Editable adds inline form")
+    assert.equal($('#select-sorted-tester form').length, 1, 'Clicking Editable adds inline form');
 
     var options_list = []
     $('#select-sorted-tester option').each(function(name, val) { options_list.push(val.text); });
 
-    assert.deepEqual(options_list, ["Letter Disk", "Letter E", "Letter F"], "It does sort the given options list");
+    assert.deepEqual(options_list, ['Letter Disk', 'Letter E', 'Letter F'], 'It does sort the given options list');
 });
-QUnit.module("select-boxes setting selected");
-QUnit.test("Explicitly setting a selected option", function(assert) {
+QUnit.module('select-boxes setting selected');
+QUnit.test('Explicitly setting a selected option', function(assert) {
     elem.append( "<span id='selected-tester'>Letter F</span>" );
 
-    $.fn.editable.defaults.sort_select_options = false;
+    $.fn.editable.defaults.sortSelectOptions = false;
 
     $('#selected-tester').editable('http://bla', {
         type: 'select',
-        data: {"E": "Letter E", "F": "Letter F", "D": "Letter Disk", "selected": "F"},
+        data: {'E': 'Letter E', 'F': 'Letter F', 'D': 'Letter Disk', 'selected': 'F'},
     });
 
-    assert.equal( $( "#selected-tester").attr('title'), "Click to edit", "Editable enabled: it sets the title" );
+    assert.equal( $( '#selected-tester').attr('title'), 'Click to edit', 'Editable enabled: it sets the title' );
     $('#selected-tester').click();
-    assert.equal($('#selected-tester form select :selected').text(), 'Letter F', "Sets the correct value as selected")
+    assert.equal($('#selected-tester form select :selected').text(), 'Letter F', 'Sets the correct value as selected')
 });
-QUnit.test("Not setting a selected option", function(assert) {
+QUnit.test('Not setting a selected option', function(assert) {
     elem.append( "<span id='selected-tester'>Letter F</span>" );
 
-    $.fn.editable.defaults.sort_select_options = false;
+    $.fn.editable.defaults.sortSelectOptions = false;
 
     $('#selected-tester').editable('http://bla', {
         type: 'select',
-        data: {"E": "Letter E", "F": "Letter F", "D": "Letter Disk"},
+        data: {'E': 'Letter E', 'F': 'Letter F', 'D': 'Letter Disk'},
     });
 
-    assert.equal( $( "#selected-tester").attr('title'), "Click to edit", "Editable enabled: it sets the title" );
+    assert.equal( $( '#selected-tester').attr('title'), 'Click to edit', 'Editable enabled: it sets the title' );
     $('#selected-tester').click();
-    assert.equal($('#selected-tester form select :selected').text(), 'Letter E', "Selects the first option as selected?")
+    assert.equal($('#selected-tester form select :selected').text(), 'Letter E', 'Selects the first option as selected?');
 });
 


### PR DESCRIPTION
> As mentioned in the the PR default text, I targeted the "experimental" branch!

So maybe this is not ideal, but the first two commits were discussed in #167 (and #176) where I 

- make sure the key is used when setting a selected value
- make sure the sorting is optional 

I set the default option to not-sorted, which may not be your "default" choice. That could easily by changed? I added tests for these two cases. 

Furthermore I added a naive approach to prevent double submits. I noticed in my code that every form.submit was called twice. I was not able to get to the real cause of that, but did manage a simple work-around preventing it.

I hope this is useful. If you have any feedback, let me know. 

 