### PR TITLE
Pass the event to the 'before' callback

### DIFF
--- a/src/jquery.jeditable.js
+++ b/src/jquery.jeditable.js
@@ -160,7 +160,7 @@
 
                 /* execute the before function if any was specified */
                 if (settings.before && jQuery.isFunction(settings.before)) {
-                    settings.before();
+                    settings.before(e);
                 } else if (settings.before && !jQuery.isFunction(settings.before)) {
                     throw "The 'before' option needs to be provided as a function!";
                 }


### PR DESCRIPTION
I found myself needing to use the event object in the 'before' callback, and I made this change to help me out. I needed to know who triggered the event.

The change should be backwards compatible.