### PR TITLE
Get text instead of html for callback result

### DIFF
--- a/src/jquery.jeditable.js
+++ b/src/jquery.jeditable.js
@@ -374,7 +374,7 @@
                                   if (false !== complete) {
                                       $(self).html(value);
                                       self.editing = false;
-                                      callback.apply(self, [self.innerHTML, settings]);
+                                      callback.apply(self, [self.innerText, settings]);
                                       if (!$.trim($(self).html())) {
                                           $(self).html(settings.placeholder);
                                       }


### PR DESCRIPTION
Currently, the callback option function returns innerHTML as a result. [This means the value that gets returned will have HTML entities](https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML) like `&amp;`. You can see this in action in this jsfiddle:
https://jsfiddle.net/mhrvzdas/3/

It seems like it would be more useful to return the text content that the user edited into place rather than its HTML representation. This commit makes this happen.

