### PR TITLE
Update to enable shift+enter to submit form

### DIFF
--- a/src/jquery.jeditable.js
+++ b/src/jquery.jeditable.js
@@ -312,6 +312,10 @@
                     if (e.which === 27) {
                         e.preventDefault();
                         reset.apply(form, [settings, self]);
+                    /* allow shift+enter to submit form (required for textarea) */
+                    } else if (e.which == 13 && e.shiftKey){
+                        e.preventDefault();
+                        form.trigger('submit');
                     }
                 });
 


### PR DESCRIPTION
Textarea fields without visible buttons can't be submitted since press enter performs a carriage return. Use shift+enter to save.
